### PR TITLE
Add minimal option for auth proxy cookie size

### DIFF
--- a/common-applications/control/jenkins/oauth-proxy.yaml
+++ b/common-applications/control/jenkins/oauth-proxy.yaml
@@ -35,6 +35,8 @@ spec:
             # for webhook to be triggered
             - --skip-auth-regex=^/gitee-project/
             - --custom-sign-in-logo=https://openeulerinfrastructure.obs.cn-north-4.myhuaweicloud.com/img/gardener-large.png
+            # reduce header size in case of 431 error
+            - --session-cookie-minimal=true
           env:
             - name: OAUTH2_PROXY_CLIENT_ID
               valueFrom:


### PR DESCRIPTION
Add --session-cookie-minimal option to reduce cookie size generated by oauth proxy in case of 431 error