### PR TITLE
Fix the openeuler/git_commit service bug: there is no space to clone repo because of failure to delete the repo and update white_git to the newest version

### DIFF
--- a/common-applications/om/om-collect/kunpeng/git_commit/kustomization.yaml
+++ b/common-applications/om/om-collect/kunpeng/git_commit/kustomization.yaml
@@ -12,6 +12,6 @@ patchesStrategicMerge:
 images:
   - name: swr.cn-north-4.myhuaweicloud.com/om/om-collect
     newName: swr.cn-north-4.myhuaweicloud.com/om/om-collection
-    newTag: 0.1.71
+    newTag: 0.1.72
 namePrefix: git-commit-
 

--- a/common-applications/om/om-collect/kunpeng/white_git/kustomization.yaml
+++ b/common-applications/om/om-collect/kunpeng/white_git/kustomization.yaml
@@ -12,6 +12,6 @@ patchesStrategicMerge:
 images:
   - name: swr.cn-north-4.myhuaweicloud.com/om/om-collect
     newName: swr.cn-north-4.myhuaweicloud.com/om/om-collection
-    newTag: 0.1.52
+    newTag: 0.1.72
 namePrefix: white-git-
 


### PR DESCRIPTION
update version  git_commit & white_git service for kunpeng to 0.1.72