### PR TITLE
Update version to 0.1.74 for git_commit and white_git in kunpeng

### DIFF
--- a/common-applications/om/om-collect/kunpeng/git_commit/kustomization.yaml
+++ b/common-applications/om/om-collect/kunpeng/git_commit/kustomization.yaml
@@ -12,6 +12,6 @@ patchesStrategicMerge:
 images:
   - name: swr.cn-north-4.myhuaweicloud.com/om/om-collect
     newName: swr.cn-north-4.myhuaweicloud.com/om/om-collection
-    newTag: 0.1.72
+    newTag: 0.1.74
 namePrefix: git-commit-
 

--- a/common-applications/om/om-collect/kunpeng/white_git/kustomization.yaml
+++ b/common-applications/om/om-collect/kunpeng/white_git/kustomization.yaml
@@ -12,6 +12,6 @@ patchesStrategicMerge:
 images:
   - name: swr.cn-north-4.myhuaweicloud.com/om/om-collect
     newName: swr.cn-north-4.myhuaweicloud.com/om/om-collection
-    newTag: 0.1.72
+    newTag: 0.1.74
 namePrefix: white-git-
 


### PR DESCRIPTION
Fix the bug that git_commit cannot prepare enough space fore repo in time