### PR TITLE
query by pageSize remove redis cach

### DIFF
--- a/common-applications/om/om-webserver/deployment.yaml
+++ b/common-applications/om/om-webserver/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: om-webserver
-          image: swr.cn-north-4.myhuaweicloud.com/om/om-webserver:0.0.48
+          image: swr.cn-north-4.myhuaweicloud.com/om/om-webserver:0.0.49
           resources:
             requests:
               memory: 100Mi


### PR DESCRIPTION
query by pageSize remove redis cach