### PR TITLE
修复/project接口bug

### DIFF
--- a/common-applications/om/datastat-server/deployment.yaml
+++ b/common-applications/om/datastat-server/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       - name: huawei-swr-image-pull-secret
       containers:
         - name: datastat-server
-          image: swr.cn-north-4.myhuaweicloud.com/om/ds:0.0.92
+          image: swr.cn-north-4.myhuaweicloud.com/om/ds:0.0.96
           resources:
             limits:
               cpu: 2000m


### PR DESCRIPTION
两项更新。
1)修复/project接口bug。
变量projectQueryStr是用于查询ES数据库的字符串。之前为了测试查询字符串为空时执行查询操作是否会报错，将projectQueryStr=“”。测试完成后没有删除projectQueryStr=“”，导致/project接口无法使用。因此删除projectQueryStr=“”。
2)测试/trace接口乱码问题。