### PR TITLE
update package version in datastat-server 

### DIFF
--- a/common-applications/om/datastat-server/deployment.yaml
+++ b/common-applications/om/datastat-server/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       - name: huawei-swr-image-pull-secret
       containers:
         - name: datastat-server
-          image: swr.cn-north-4.myhuaweicloud.com/om/ds:0.1.9
+          image: swr.cn-north-4.myhuaweicloud.com/om/ds:0.1.10
           resources:
             limits:
               cpu: 2000m


### PR DESCRIPTION
对应https://github.com/opensourceways/datastat-server/pull/121
测试/sig/score返回401的可能原因。